### PR TITLE
fix isContentDecrypt in editor signed policy

### DIFF
--- a/auth/common_policies/editor_signed_policy.yaml
+++ b/auth/common_policies/editor_signed_policy.yaml
@@ -1,4 +1,4 @@
-name: Policy Sample v1.4
+name: Policy Sample v1.5
 desc: |
   Sample policy for editor signed tokens that checks authorized_meta,
   authorized_files, authorized_reps and authorized_offerings values in

--- a/auth/common_policies/editor_signed_policy.yaml
+++ b/auth/common_policies/editor_signed_policy.yaml
@@ -5,6 +5,10 @@ desc: |
   the token/ctx
 
   Changelog:
+  v1.5
+    * fix isContentDecrypt 
+       * comparison of call/subject and call/node_id
+       * allow read part
   v1.4
     * when token does not have authorized_xxxx accept rather than refusing any value:
       * accept offering if nil authorized_offerings
@@ -109,12 +113,13 @@ rules:
 
   isContentDecrypt:
     and:
-      - eq:
+      - in:
           - env: api_call/action
-          - q.read.decrypt
-      - eq:
-          - env: api_call/subject
-          - env: api_call/node_id
+          - - q.read.part.read
+            - q.read.decrypt
+      - fn.ids.Equivalent:
+          - env: call/subject
+          - env: call/node_id
 
   publicContent:
     and:
@@ -143,22 +148,22 @@ rules:
       - nil:
           env: token/ctx/authorized_reps
       - in:
-        # the rep name is the first segment in the bcCallPath:
-        #   /rep/playout/offering/...
-        #   /rep/media_download/offering/...
-        # /rep is not part of bcCallPath (it's mapped to the "content" bitcode function)
-        - rule: bcCallPath/0
-        - env: token/ctx/authorized_reps
+          # the rep name is the first segment in the bcCallPath:
+          #   /rep/playout/offering/...
+          #   /rep/media_download/offering/...
+          # /rep is not part of bcCallPath (it's mapped to the "content" bitcode function)
+          - rule: bcCallPath/0
+          - env: token/ctx/authorized_reps
 
   permittedOfferings:
     and:
-       - rule: permittedRep
-       - or:
+      - rule: permittedRep
+      - or:
           - and:
               - rule: isPlayout
               - eq:
-                - rule: bcCallPath/1
-                - "options.json"
+                  - rule: bcCallPath/1
+                  - "options.json"
           - or:
               - nil:
                   env: token/ctx/authorized_offerings

--- a/auth/editor_signed_tokens.md
+++ b/auth/editor_signed_tokens.md
@@ -93,7 +93,7 @@ and store the policy created in previous step. This:
 * stores the policy in the delegate
 
 ```
-./qfab_cli content policy set ilib1234 tqw_6K52PR6yhNJDTh5526T8TtNbQf7QZufwQ @policy.yaml --qid iq__1234
+./qfab_cli content policy set tqw_6K52PR6yhNJDTh5526T8TtNbQf7QZufwQ @policy.yaml --qid iq__1234
 
 {
 	"hash" : "hq__1234",
@@ -101,6 +101,11 @@ and store the policy created in previous step. This:
 }
 
 ```
+
+**note:** in order to update a policy in an existing delegate: 
+
+* skip the step `create policy object`
+* proceed with the step to store the policy using the command `content policy set iq__4567`
 
 ### Create an Editor-Signed Token with Permissions
 


### PR DESCRIPTION
* comparison of call/subject and call/node_id
* allow read part

---
**How to test**

1. on demo network (see [fabric/#2195](https://github.com/qluvio/content-fabric/issues/2195)): 
  * update a content that uses an editor signed policy. See [editor_signed_tokens.md](https://github.com/eluv-io/elv-docs/blob/main/auth/editor_signed_tokens.md). 
  * test using a node that has the fabric branch `auth-use-new-tokens`
  * test using a node that has the fabric branch `develop`

2. Set the policy to prod contents: must still work with develop



