### PR TITLE
Add nft-owner-or-admin policy

### DIFF
--- a/auth/README.md
+++ b/auth/README.md
@@ -58,14 +58,18 @@ CSATs can be assessed against authorization policies, with one important differe
 the token signer. With ESATs, the fabric node verifies that the token signer has edit rights before policy evaluation;
 with a CSAT the node does not pre-validate the signer, so the policy's entry point must do it explicitly.
 
-CSAT policies must follow this pattern:
+CSAT policies should follow this pattern:
 
 * Name the top-level entry point rule `authorize` (the `expr` block points to it)
 * Include an `isValidTokenSigner` rule that checks `env: token/adr` against a list of authorized signer addresses
 * Gate all access through `authorize` so the signer check cannot be bypassed
 
 The [IP/Geo Policy](sample_policies/policy-ip-geo.yaml) and [Cross-Chain NFT Policy](sample_policies/nft_cross_chain.yml) are
-both CSAT policy examples and show this pattern in full.
+both CSAT policy examples and show this pattern.
+
+`isValidTokenSigner` may be omitted when the policy independently verifies the user's identity via a
+on-chain lookup rather than trusting anything carried in the token.  [NFT Owner Policy](common_policies/nft_owner.yaml) and
+[NFT Owner + Admin Policy](common_policies/nft_owner_or_admin.yaml) are examples of this.
 
 
 ### Appendix: Token Types and Policy Interaction

--- a/auth/README.md
+++ b/auth/README.md
@@ -19,8 +19,7 @@ Ready-to-use policies for common access control scenarios:
 * [NFT Owner + Minter Policy](common_policies/nft_owner_minter.yaml) -- Same as NFT Owner, but also grants access
   to a designated user address (e.g. a minter account).
 * [NFT Owner + Admin Policy](common_policies/nft_owner_or_admin.yaml) -- Same as NFT Owner, but also grants access
-  to any user who is a member of the `tenant_admin` or `content_admin` blockchain group (live group membership
-  check via `userIsTenantAdmin` / `userIsContentAdmin`).
+  to any user who is a member of the `tenant_admin` or `content_admin` group for the object
 
 Annotated examples illustrating specific policy features:
 

--- a/auth/README.md
+++ b/auth/README.md
@@ -18,6 +18,9 @@ Ready-to-use policies for common access control scenarios:
   content object's linked ERC-721 smart contract.
 * [NFT Owner + Minter Policy](common_policies/nft_owner_minter.yaml) -- Same as NFT Owner, but also grants access
   to a designated user address (e.g. a minter account).
+* [NFT Owner + Admin Policy](common_policies/nft_owner_or_admin.yaml) -- Same as NFT Owner, but also grants access
+  to any user who is a member of the `tenant_admin` or `content_admin` blockchain group (live group membership
+  check via `userIsTenantAdmin` / `userIsContentAdmin`).
 
 Annotated examples illustrating specific policy features:
 

--- a/auth/common_policies/nft_owner_or_admin.yaml
+++ b/auth/common_policies/nft_owner_or_admin.yaml
@@ -1,0 +1,29 @@
+name: policy nft-owner-or-admin v1.0
+desc: |
+  Contract policy for access control based on NFT ownership, with access also granted to tenant
+  and content administrators. The policy permits any read operation if the user owns a
+  non-fungible token governed by a linked ERC-721 smart contract, or is a member of the
+  tenant_admin or content_admin blockchain group.
+type: ast
+expr:
+  rule: main
+rules:
+
+  main:
+    or:
+      - fn.isOwnerOfLinkedNft:
+          - env: call/subject
+      - rule: isAdminUser
+      - and:
+          - eq:
+              - env: api_call/action
+              - q.read.decrypt
+          - fn.ids.Equivalent:
+              - env: call/node_id
+              - env: call/subject
+
+  # grants access to tenant and content administrators via live blockchain group membership check
+  isAdminUser:
+    or:
+      - func: userIsTenantAdmin
+      - func: userIsContentAdmin

--- a/auth/common_policies/nft_owner_or_admin.yaml
+++ b/auth/common_policies/nft_owner_or_admin.yaml
@@ -6,8 +6,7 @@ desc: |
   tenant_admin or content_admin blockchain group.
 
   Entry point is named "authorize" so the policy accepts client-signed tokens (CSATs) in addition
-  to editor-signed and state channel tokens. No signer allowlist is required: the admin check
-  makes a live blockchain call against call/subject, so group membership is the trust anchor.
+  to editor-signed and state channel tokens.
 type: ast
 expr:
   rule: authorize
@@ -33,7 +32,7 @@ rules:
               - env: call/node_id
               - env: call/subject
 
-  # grants access to tenant and content administrators via live blockchain group membership check
+  # uses runtime-injected environment functions
   isAdminUser:
     or:
       - func: userIsTenantAdmin

--- a/auth/common_policies/nft_owner_or_admin.yaml
+++ b/auth/common_policies/nft_owner_or_admin.yaml
@@ -1,19 +1,30 @@
-name: policy nft-owner-or-admin v1.0
+name: policy nft-owner-or-admin v1.1
 desc: |
   Contract policy for access control based on NFT ownership, with access also granted to tenant
   and content administrators. The policy permits any read operation if the user owns a
   non-fungible token governed by a linked ERC-721 smart contract, or is a member of the
   tenant_admin or content_admin blockchain group.
+
+  Entry point is named "authorize" so the policy accepts client-signed tokens (CSATs) in addition
+  to editor-signed and state channel tokens. No signer allowlist is required: the admin check
+  makes a live blockchain call against call/subject, so group membership is the trust anchor.
 type: ast
 expr:
-  rule: main
+  rule: authorize
 rules:
+
+  # Entry point for client-signed tokens (CSATs); also used by ESAT/state channel tokens.
+  # isAdminUser runs first: fn.isOwnerOfLinkedNft propagates errors rather than returning false,
+  # so if the NFT contract is missing or invalid, main would error before isAdminUser could run.
+  authorize:
+    or:
+      - rule: isAdminUser
+      - rule: main
 
   main:
     or:
       - fn.isOwnerOfLinkedNft:
           - env: call/subject
-      - rule: isAdminUser
       - and:
           - eq:
               - env: api_call/action


### PR DESCRIPTION
for /rep/search  -- to keep it Editable instead of Publicly Listable,
but accessible from the token type we point tenants to use for entitlement from the backend, a elv-client-js.CreateFabricToken(),

let's see if we can make a policy that:
- can check is member of group 
- against group list: tenant admin or content admin

## testing

and test it against vub TEST `iq__45mT1BtYJcyVN2Jt3psyBF3anVgz`

worked!

## application

we'll keep TEST as Public, but, i reverted PROD `iq__4FB4SYgqejRDJdhvcW9jDFP4SHoi` back to Editable and applied the policy, and confirmed

```
$ curl -s -H "Authorization: Bearer $tok" 'https://host-76-74-35-67.contentfabric.io/q/iq__4FB4SYgqejRDJdhvcW9jDFP4SHoi/rep/search?terms=(f_modified_string%3A%5B2026-01-15+TO+2027-02-18T19:00:00.000Z%5D)+AND+(f_asset_type%3Aprimary)&select=%2Fpublic%2Fasset_metadata&start=0&limit=1000' | jq |head
{
  "pagination": {
    "limit": 1000,
    "max_total": 80,
    "start": 0,
    "total": 1
  },
  "results": [
    {
      "fields": {},
```
